### PR TITLE
直接使用子切片导致的内存泄漏问题

### DIFF
--- a/netstat.go
+++ b/netstat.go
@@ -1,6 +1,7 @@
 package netflow
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -65,8 +66,16 @@ func parseNetworkLines(tp string) ([]string, error) {
 		return nil, err
 	}
 
-	lines := strings.Split(string(data), "\n")
-	return lines[1 : len(lines)-1], nil
+	lines := bytes.Split(data, []byte("\n"))
+	var netString []string
+	fileLens := len(lines)
+	for i, line := range lines {
+		if i == 0 || i == fileLens-1 {
+			continue
+		}
+		netString = append(netString, string(line))
+	}
+	return netString, nil
 }
 
 func hex2dec(hexstr string) string {


### PR DESCRIPTION
直接截取切片，并且通过函数在别处使用，导致暂时性泄漏
如果是周期性调用且高于gc频率，则为永久性泄漏现象